### PR TITLE
Add option to use bright colors

### DIFF
--- a/colors/colors.py
+++ b/colors/colors.py
@@ -66,6 +66,9 @@ def _color_code(spec, base):
     """
     if is_string(spec):
         spec = spec.strip().lower()
+        if spec.startswith('bright'):
+            base += 60
+            spec = spec[6:]
 
     if spec == 'default':
         return _join(base + 9)

--- a/show_colors.py
+++ b/show_colors.py
@@ -22,7 +22,7 @@ def test_styles(bg, fg):
 # test on standard 80-column terminal
 
 colors  = [None,] + list(COLORS[:8])
-brights = list(COLORS[8:])
+brights = ['bright' + c for c in COLORS]
 
 for bg in colors:
     for fg in colors:


### PR DESCRIPTION
Colors can now be passed to `color` function with `bright` prefix. This should be compatible with most terminals, whereas using idiosyncratic 256-color scheme for brighter shades of colors might not be.

`show_colors.py` was also changed to print every possibility including bright colors.