### PR TITLE
Use a precompiled regex for strip_color (2.7 to 4x faster)

### DIFF
--- a/colors/colors.py
+++ b/colors/colors.py
@@ -30,6 +30,8 @@ COLORS = ('black', 'red', 'green', 'yellow', 'blue',
 STYLES = ('none', 'bold', 'faint', 'italic', 'underline', 'blink',
           'blink2', 'negative', 'concealed', 'crossed')
 
+_STRIP_COLOR_RE = re.compile('\x1b\\[(K|.*?m)')
+
 
 def is_string(obj):
     """
@@ -128,7 +130,7 @@ def strip_color(s):
     erase to end of line) and `\x1b[m`, a terse version of the more common
     `\x1b[0m`.
     """
-    return re.sub('\x1b\\[(K|.*?m)', '', s)
+    return _STRIP_COLOR_RE.sub('', s)
 
 
 def ansilen(s):


### PR DESCRIPTION
This speeds up `strip_color` and `ansilen` by precompiling the regex.

### String without color code

* Before:

```
python -m timeit -s 'import re; s = "abcdefghijklmnopqrstuvwxyz"' 're.sub("\x1b\\[(K|.*?m)", "", s)'
500000 loops, best of 5: 822 nsec per loop
```

* After:

```
python -m timeit -s 'import re; s = "abcdefghijklmnopqrstuvwxyz"; r = re.compile("\x1b\\[(K|.*?m)")' 'r.sub("", s)'
1000000 loops, best of 5: 202 nsec per loop
```

**=> ~4x speedup**

### String with color code

* Before:

```
python -m timeit -s 'import re; s = "abcdefghij\x1b[30mklmnop\1b[0mqrstuvwxyz"' 're.sub("\x1b\\[(K|.*?m)", "", s)'
200000 loops, best of 5: 1.47 usec per loop
```

* After:

```
python -m timeit -s 'import re; s = "abcdefghij\x1b[30mklmnop\1b[0mqrstuvwxyz"; r = re.compile("\x1b\\[(K|.*?m)")' 'r.sub("", s)'
500000 loops, best of 5: 547 nsec per loop
```

**=> ~2.7x speedup**